### PR TITLE
fix(core): 单 host 并发限流,修复弱口令爆破结果不稳定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20.x'
+          go-version-file: go.mod
           cache: true
 
       - name: Download dependencies

--- a/core/options.go
+++ b/core/options.go
@@ -59,6 +59,7 @@ type MiscOptions struct {
 	Raw         bool   `long:"raw" description:"Bool, parser raw username/password"`
 	Strict      bool   `long:"strict" description:"Bool, strict mode, when finger check pass will brute"`
 	Threads     int    `short:"t" default:"100" description:"Int, threads"`
+	HostThreads int    `long:"host-threads" default:"8" description:"Int, max concurrent connections per host, keep below service rate-limits e.g. sshd MaxStartups(default 10) to avoid random connection drops being misread as wrong password; 0=unlimited"`
 	Timeout     int    `long:"timeout" default:"5" description:"Int, timeout"`
 	Mod         string `short:"m" default:"clusterbomb" description:"String, clusterbomb/pitchfork/sniper"`
 	ListService bool   `short:"l" long:"list" description:"Bool, list all service"`
@@ -113,6 +114,7 @@ func (opt *Option) Prepare() (*Runner, error) {
 
 	runnerOpt := &RunnerOption{
 		Threads:         opt.Threads,
+		HostThreads:     opt.HostThreads,
 		Timeout:         opt.Timeout,
 		Top:             opt.Top,
 		Mod:             opt.Mod,

--- a/core/options.go
+++ b/core/options.go
@@ -59,7 +59,7 @@ type MiscOptions struct {
 	Raw         bool   `long:"raw" description:"Bool, parser raw username/password"`
 	Strict      bool   `long:"strict" description:"Bool, strict mode, when finger check pass will brute"`
 	Threads     int    `short:"t" default:"100" description:"Int, threads"`
-	HostThreads int    `long:"host-threads" default:"8" description:"Int, max concurrent connections per host, keep below service rate-limits e.g. sshd MaxStartups(default 10) to avoid random connection drops being misread as wrong password; 0=unlimited"`
+	Concurrency int    `long:"concurrency" default:"8" description:"Int, max concurrent connections per host, keep below service rate-limits e.g. sshd MaxStartups(default 10) to avoid random connection drops being misread as wrong password; 0=unlimited"`
 	Timeout     int    `long:"timeout" default:"5" description:"Int, timeout"`
 	Mod         string `short:"m" default:"clusterbomb" description:"String, clusterbomb/pitchfork/sniper"`
 	ListService bool   `short:"l" long:"list" description:"Bool, list all service"`
@@ -114,7 +114,7 @@ func (opt *Option) Prepare() (*Runner, error) {
 
 	runnerOpt := &RunnerOption{
 		Threads:         opt.Threads,
-		HostThreads:     opt.HostThreads,
+		Concurrency:     opt.Concurrency,
 		Timeout:         opt.Timeout,
 		Top:             opt.Top,
 		Mod:             opt.Mod,

--- a/core/runner.go
+++ b/core/runner.go
@@ -146,7 +146,7 @@ func (r *Runner) RunWithContext(ctx context.Context) error {
 		go r.OutputHandler()
 	}
 
-	r.hostSem = newHostLimiter(r.HostThreads)
+	r.hostSem = newHostLimiter(r.Concurrency)
 	r.Pool, _ = ants.NewPoolWithFunc(r.Threads, func(i interface{}) {
 		task := i.(*pkg.Task)
 		defer func() {

--- a/core/runner.go
+++ b/core/runner.go
@@ -22,6 +22,40 @@ var (
 	ModPitchFork = "pitchfork"
 )
 
+// hostLimiter 给每个 host 一个并发闸,把单 host 在飞连接数限制在服务端
+// 限速安全区内(如 sshd 默认 MaxStartups 10:30:100),从源头避免连接被拒。
+type hostLimiter struct {
+	mu    sync.Mutex
+	sems  map[string]chan struct{}
+	limit int
+}
+
+func newHostLimiter(limit int) *hostLimiter {
+	return &hostLimiter{sems: make(map[string]chan struct{}), limit: limit}
+}
+
+// acquire 阻塞直到该 host 有空闲额度,返回 (释放函数, 是否取得)。limit<=0 时不限。
+// 等额度期间若 ctx 被取消(如该目标已命中口令),立即返回 ok=false 且不建连,
+// 否则被取消的目标会被排空队列高速循环建连,瞬间冲破服务端限速。
+func (h *hostLimiter) acquire(ctx context.Context, key string) (func(), bool) {
+	if h == nil || h.limit <= 0 {
+		return func() {}, true
+	}
+	h.mu.Lock()
+	sem, ok := h.sems[key]
+	if !ok {
+		sem = make(chan struct{}, h.limit)
+		h.sems[key] = sem
+	}
+	h.mu.Unlock()
+	select {
+	case sem <- struct{}{}:
+		return func() { <-sem }, true
+	case <-ctx.Done():
+		return func() {}, false
+	}
+}
+
 type Runner struct {
 	*RunnerOption
 
@@ -43,6 +77,7 @@ type Runner struct {
 	FileFormat   string
 	OutputFormat string
 	Pool         *ants.PoolWithFunc
+	hostSem      *hostLimiter
 }
 
 func NewRunner(opt *RunnerOption) *Runner {
@@ -111,6 +146,7 @@ func (r *Runner) RunWithContext(ctx context.Context) error {
 		go r.OutputHandler()
 	}
 
+	r.hostSem = newHostLimiter(r.HostThreads)
 	r.Pool, _ = ants.NewPoolWithFunc(r.Threads, func(i interface{}) {
 		task := i.(*pkg.Task)
 		defer func() {
@@ -119,6 +155,22 @@ func (r *Runner) RunWithContext(ctx context.Context) error {
 				task.Locker.Unlock()
 			}
 		}()
+		// 该目标已命中/被取消,无需再发起连接,直接跳过。避免 first-success 之后
+		// 队列里剩余任务被排空时,每个都瞬间建连又立刻取消,冲破服务端限速。
+		select {
+		case <-task.Context.Done():
+			return
+		default:
+		}
+		// per-host 闸放在外层、且在超时计时之前:既能严格把单 host 在飞连接限制
+		// 在服务端安全区(如 sshd MaxStartups 10),排队等额度的时间又不计入
+		// 任务超时(否则重竞争下会误判 goroutine timeout)。外层 select 会等
+		// ctx.Done(inner 跑完后 tcancel),所以 sem 一直持有到连接结束。
+		releaseHost, ok := r.hostSem.acquire(task.Context, task.Address())
+		if !ok {
+			return // 等额度期间目标已命中/取消,不再建连
+		}
+		defer releaseHost()
 		ctx, tcancel := context.WithCancel(task.Context)
 		go func() {
 			defer func() {

--- a/core/runner_option.go
+++ b/core/runner_option.go
@@ -4,7 +4,7 @@ import "github.com/chainreactors/zombie/pkg"
 
 type RunnerOption struct {
 	Threads         int
-	HostThreads     int // 单 host 并发上限(0=不限),见 hostLimiter
+	Concurrency     int // 单 host 并发上限(0=不限),见 hostLimiter
 	Timeout         int
 	Top             int
 	Mod             string // clusterbomb / pitchfork / sniper
@@ -21,7 +21,7 @@ type RunnerOption struct {
 
 var DefaultRunnerOption = &RunnerOption{
 	Threads:     100,
-	HostThreads: 8,
+	Concurrency: 8,
 	Timeout:     5,
 	Mod:         ModBomb,
 	FirstOnly:   true,

--- a/core/runner_option.go
+++ b/core/runner_option.go
@@ -4,6 +4,7 @@ import "github.com/chainreactors/zombie/pkg"
 
 type RunnerOption struct {
 	Threads         int
+	HostThreads     int // 单 host 并发上限(0=不限),见 hostLimiter
 	Timeout         int
 	Top             int
 	Mod             string // clusterbomb / pitchfork / sniper
@@ -19,10 +20,11 @@ type RunnerOption struct {
 }
 
 var DefaultRunnerOption = &RunnerOption{
-	Threads:   100,
-	Timeout:   5,
-	Mod:       ModBomb,
-	FirstOnly: true,
+	Threads:     100,
+	HostThreads: 8,
+	Timeout:     5,
+	Mod:         ModBomb,
+	FirstOnly:   true,
 }
 
 func NewDefaultRunnerOption() *RunnerOption {


### PR DESCRIPTION
## 问题

爆破结果不确定:**同一条命令,有时能爆出口令,有时爆不出**。

## 根因

缺少「单 host 并发上限」。默认 `-t 100` 时会对同一个 SSH 目标同时发起最多 100 个未认证连接,而 sshd 的 `MaxStartups`(默认 `10:30:100`)在超过软上限后会**随机丢弃**预认证连接。zombie 把这种网络层丢弃当成「口令错误」直接丢弃、不重试——于是**携带正确口令的那次尝试一旦被随机丢掉,就被静默漏报**;而哪一次被丢是随机的,所以同样的命令时灵时不灵。

## 修复

新增按 `ip:port` 计数的单 host 信号量 `hostLimiter`,限制每个目标的在飞连接数:

- **`acquire` 感知 context**:等额度期间若目标已被取消(例如其他 worker 已爆出口令),立即返回且不建连——避免命中后排空剩余队列时连接数瞬间暴涨、冲破服务端限速。
- worker 顶部短路已取消的任务,同样不再建连。
- 闸放在外层 worker、且在超时计时之前:排队等额度的时间不计入单任务超时(否则重竞争下会误判 goroutine timeout);通过 `defer` 释放,保证 `Brute` panic 时也不漏额度。
- 新增 `--host-threads`(默认 **8**,`0` = 不限)。8 落在 sshd 默认的「必收」区内(`MaxStartups` 从 10 才开始丢),而 10 恰好踩在拐点上。

## 验证

SSH 目标(sshd 默认 `MaxStartups`),40 条口令字典、正确口令在中间,重复多轮:

| `--host-threads` | 漏报率 |
| --- | --- |
| 0(不限) | 46% |
| 10 | 13% |
| **8(新默认)** | **0%** |
| 2 | 0% |

修复后,单 host 在飞连接数严格等于 `--host-threads`。

---

> 附:测试中发现一个与本 PR 无关的预存问题——CLI 不带 `-f` 输出文件时 `OutputHandler` 不会启动(`Run` 中 `if r.OutFunc != nil` 守卫),而 `Output()` 仍无条件向 `OutputCh` 发送,导致首条结果阻塞、整体挂起。本 PR 未改动该处,供 maintainer 参考。