### PR TITLE
fix(zombie2.0): 修复 PR #70 靶场实测的 4 个运行时 bug(死锁 / send-on-closed 竞态 / -s SIGSEGV / mongo 未授权)

### DIFF
--- a/core/mongo_unauth_test.go
+++ b/core/mongo_unauth_test.go
@@ -1,0 +1,30 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/chainreactors/parsers"
+	"github.com/chainreactors/zombie/pkg"
+	"github.com/chainreactors/zombie/plugin"
+	mongoplugin "github.com/chainreactors/zombie/plugin/mongo"
+)
+
+func TestMongoUnauthUsesRealProbe(t *testing.T) {
+	task := &pkg.Task{
+		ZombieResult: &parsers.ZombieResult{
+			IP:      "127.0.0.1",
+			Port:    "27017",
+			Service: "mongo",
+			Mod:     parsers.ZombieModUnauth,
+		},
+		Timeout: 2,
+	}
+	plugins := map[string]plugin.Plugin{"mongo": &mongoplugin.MongoPlugin{}}
+
+	res := ExecuteUnauth(task, plugins, nil, nil)
+
+	if errors.Is(res.Err, pkg.NotImplUnauthorized) {
+		t.Fatalf("mongo Unauth is still a stub (NotImplUnauthorized)")
+	}
+}

--- a/core/options.go
+++ b/core/options.go
@@ -103,6 +103,20 @@ func (opt *Option) Validate() error {
 	if opt.UsernameRule != "" && (opt.Username == nil && opt.UsernameFile == "") {
 		return errors.New("use custom username rule must set username, please set -u/-U")
 	}
+	// 校验 -s 指定的服务名:未注册的服务名(memcache/postgres/8080…)在 Prepare 阶段会经
+	// DefaultPort 触发崩溃或后续静默 0,这里提前友好报错。用 NormalizeService 以接受别名
+	// (postgre/mongodb 等),且与执行期 canonical 解析口径一致。
+	if opt.ServiceName != "" {
+		for _, name := range strings.Split(opt.ServiceName, ",") {
+			if strings.TrimSpace(name) == "" {
+				continue
+			}
+			if _, _, ok := pkg.NormalizeService(name); !ok {
+				return fmt.Errorf("unknown service %q, supported services: %s",
+					strings.ToLower(strings.TrimSpace(name)), pkg.SupportedServiceNames())
+			}
+		}
+	}
 	return nil
 }
 
@@ -170,7 +184,13 @@ func (opt *Option) Prepare() (*Runner, error) {
 	logs.Log.Importantf("mod: %s, check-unauth: %t, check-honeypot: %t", runner.Mod, !runner.NoUnAuth, !runner.NoCheckHoneyPot)
 
 	if opt.ServiceName != "" {
-		runner.Services = strings.Split(strings.ToLower(opt.ServiceName), ",")
+		// canonical 化:targetGenerate 的服务过滤按 canonical 名匹配(json/gogo 目标存的是
+		// canonical),别名(mongodb 等)若不归一会过滤不到任何目标。
+		for _, name := range strings.Split(opt.ServiceName, ",") {
+			if canonical, _, ok := pkg.NormalizeService(name); ok {
+				runner.Services = append(runner.Services, canonical)
+			}
+		}
 	}
 
 	if opt.JsonFile != "" {

--- a/core/options.go
+++ b/core/options.go
@@ -103,15 +103,12 @@ func (opt *Option) Validate() error {
 	if opt.UsernameRule != "" && (opt.Username == nil && opt.UsernameFile == "") {
 		return errors.New("use custom username rule must set username, please set -u/-U")
 	}
-	// 校验 -s 指定的服务名:未注册的服务名(memcache/postgres/8080…)在 Prepare 阶段会经
-	// DefaultPort 触发崩溃或后续静默 0,这里提前友好报错。用 NormalizeService 以接受别名
-	// (postgre/mongodb 等),且与执行期 canonical 解析口径一致。
 	if opt.ServiceName != "" {
 		for _, name := range strings.Split(opt.ServiceName, ",") {
 			if strings.TrimSpace(name) == "" {
 				continue
 			}
-			if _, _, ok := pkg.NormalizeService(name); !ok {
+			if _, ok := pkg.Services.Get(name); !ok {
 				return fmt.Errorf("unknown service %q, supported services: %s",
 					strings.ToLower(strings.TrimSpace(name)), pkg.SupportedServiceNames())
 			}
@@ -184,11 +181,9 @@ func (opt *Option) Prepare() (*Runner, error) {
 	logs.Log.Importantf("mod: %s, check-unauth: %t, check-honeypot: %t", runner.Mod, !runner.NoUnAuth, !runner.NoCheckHoneyPot)
 
 	if opt.ServiceName != "" {
-		// canonical 化:targetGenerate 的服务过滤按 canonical 名匹配(json/gogo 目标存的是
-		// canonical),别名(mongodb 等)若不归一会过滤不到任何目标。
 		for _, name := range strings.Split(opt.ServiceName, ",") {
-			if canonical, _, ok := pkg.NormalizeService(name); ok {
-				runner.Services = append(runner.Services, canonical)
+			if s, ok := pkg.Services.Get(name); ok {
+				runner.Services = append(runner.Services, s.Name)
 			}
 		}
 	}
@@ -244,10 +239,27 @@ func (opt *Option) Prepare() (*Runner, error) {
 		}
 	}
 
+	filterServices := map[string]struct{}{}
+	if opt.FilterService != "" {
+		for _, name := range strings.Split(opt.FilterService, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			if s, ok := pkg.Services.Get(name); ok {
+				filterServices[s.Name] = struct{}{}
+			} else {
+				filterServices[strings.ToLower(name)] = struct{}{}
+			}
+		}
+	}
+
 	for _, t := range targets {
 		// 如果指定了service, 将会覆盖json或gogo中的字段
 		if opt.ServiceName != "" {
 			t.UpdateService(opt.ServiceName)
+		} else if t.Service != "" {
+			t.UpdateService(t.Service)
 		}
 
 		if t.Service == "" {
@@ -255,15 +267,8 @@ func (opt *Option) Prepare() (*Runner, error) {
 			continue
 		}
 
-		if opt.FilterService != "" {
-			var ok bool
-			for _, s := range strings.Split(opt.FilterService, ",") {
-				if s == t.Service {
-					ok = true
-					break
-				}
-			}
-			if !ok {
+		if len(filterServices) > 0 {
+			if _, ok := filterServices[t.Service]; !ok {
 				continue
 			}
 		}

--- a/core/options_test.go
+++ b/core/options_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/chainreactors/words"
@@ -52,6 +53,94 @@ func TestOptionValidateRequiresPitchforkAuth(t *testing.T) {
 	opt.Auth = []string{"user::pass"}
 	if err := opt.Validate(); err != nil {
 		t.Fatalf("expected pitchfork with auth to pass validation: %v", err)
+	}
+}
+
+func TestOptionValidateRejectsUnknownService(t *testing.T) {
+	for _, service := range []string{"memcache", "postgres", "8080"} {
+		opt := &Option{}
+		opt.IP = []string{"127.0.0.1"}
+		opt.ServiceName = service
+		opt.Mod = ModSniper
+
+		err := opt.Validate()
+		if err == nil {
+			t.Fatalf("expected %q to be rejected", service)
+		}
+		if !strings.Contains(err.Error(), `unknown service "`+service+`"`) {
+			t.Fatalf("unexpected error for %q: %v", service, err)
+		}
+	}
+}
+
+func TestOptionPrepareCanonicalizesServiceAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		port string
+	}{
+		{name: "postgre", want: "postgresql", port: "5432"},
+		{name: "mongodb", want: "mongo", port: "27017"},
+		{name: "pop", want: "pop3", port: "110"},
+	}
+
+	for _, tt := range tests {
+		opt := &Option{}
+		opt.IP = []string{"127.0.0.1"}
+		opt.ServiceName = tt.name
+		opt.Mod = ModSniper
+
+		runner, err := opt.Prepare()
+		if err != nil {
+			t.Fatalf("Prepare(%q): %v", tt.name, err)
+		}
+		if len(runner.Targets) != 1 {
+			t.Fatalf("Prepare(%q) targets = %d, want 1", tt.name, len(runner.Targets))
+		}
+		target := runner.Targets[0]
+		if target.Service != tt.want || target.Port != tt.port {
+			t.Fatalf("Prepare(%q) target = %s:%s, want %s:%s",
+				tt.name, target.Service, target.Port, tt.want, tt.port)
+		}
+	}
+}
+
+func TestOptionPrepareKeepsOutputHandlerOptInForLibraryCallers(t *testing.T) {
+	opt := &Option{}
+	opt.IP = []string{"127.0.0.1"}
+	opt.ServiceName = "redis"
+	opt.Mod = ModSniper
+
+	runner, err := opt.Prepare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runner.OutFunc != nil {
+		t.Fatal("Prepare without output file should leave OutFunc nil")
+	}
+}
+
+func TestOptionPrepareCanonicalizesFilterServiceAliases(t *testing.T) {
+	targets := `[{"ip":"127.0.0.1","port":"5432","service":"postgresql"}]`
+	jsonFile := filepath.Join(t.TempDir(), "targets.json")
+	if err := os.WriteFile(jsonFile, []byte(targets), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	opt := &Option{}
+	opt.JsonFile = jsonFile
+	opt.FilterService = "postgre"
+	opt.Mod = ModSniper
+
+	runner, err := opt.Prepare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.Targets) != 1 {
+		t.Fatalf("targets = %d, want 1", len(runner.Targets))
+	}
+	if runner.Targets[0].Service != "postgresql" {
+		t.Fatalf("service = %q, want postgresql", runner.Targets[0].Service)
 	}
 }
 

--- a/core/run_with_args.go
+++ b/core/run_with_args.go
@@ -98,6 +98,9 @@ func RunWithArgs(ctx context.Context, args []string, opts RunOptions) error {
 	if err != nil {
 		return err
 	}
+	if runner.OutFunc == nil {
+		runner.OutFunc = func(string) {}
+	}
 	if opts.ProxyDial != nil {
 		runner.ProxyDial = opts.ProxyDial
 	}

--- a/core/run_with_args_test.go
+++ b/core/run_with_args_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunWithArgsListsServices(t *testing.T) {
@@ -27,5 +28,32 @@ func TestRunWithArgsRejectsUnsupportedMod(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported mod") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunWithArgsWithoutOutputFileDoesNotDeadlock(t *testing.T) {
+	done := make(chan error, 1)
+	go func() {
+		var out bytes.Buffer
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		done <- RunWithArgs(ctx, []string{
+			"-i", "127.0.0.1:1",
+			"-s", "redis",
+			"-m", ModSniper,
+			"-u", "default",
+			"-p", "test",
+			"--timeout", "1",
+			"-q",
+		}, RunOptions{Output: &out})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("RunWithArgs deadlocked without -f")
 	}
 }

--- a/core/runner.go
+++ b/core/runner.go
@@ -460,19 +460,8 @@ func (r *Runner) RunWithClusterBomb(ctx context.Context, targets chan *Target) {
 				locker.Unlock()
 			}
 
-			ch := r.clusterBombGenerate(targetCtx, cancel, cur)
-		loop:
-			for {
-				select {
-				case task, ok := <-ch:
-					if ok {
-						r.add(task)
-					} else {
-						break loop
-					}
-				case <-targetCtx.Done():
-					break loop
-				}
+			for task := range r.clusterBombGenerate(targetCtx, cancel, cur) {
+				r.add(task)
 			}
 		}()
 	}

--- a/core/runner.go
+++ b/core/runner.go
@@ -74,12 +74,14 @@ type Runner struct {
 	Pipeline   []pkg.Action
 	PostAction *action.PostAction
 
-	Users        *Generator
-	Pwds         *Generator
-	Auths        *Generator
-	Addrs        utils.Addrs
-	Targets      []*Target
-	Services     []string
+	Users    *Generator
+	Pwds     *Generator
+	Auths    *Generator
+	Addrs    utils.Addrs
+	Targets  []*Target
+	Services []string
+	// OutputCh 无缓冲。默认由内建 OutputHandler 消费;直接消费它的 SDK 调用方必须在
+	// Run 前置 RunnerOption.ManualDrain=true 并自行并发 drain,否则首个 Output() 会死锁。
 	OutputCh     chan *pkg.Result
 	File         *fileutils.File
 	OutFunc      func(string)
@@ -209,7 +211,11 @@ func (r *Runner) RunWithContext(ctx context.Context) error {
 		return fmt.Errorf("pitchfork mode requires auth, please set -a/-A")
 	}
 
-	if r.OutFunc != nil {
+	// OutputHandler 是无缓冲 OutputCh 的唯一内建读者兼 console 打印者,除非调用方
+	// 显式 ManualDrain 自行消费,否则必须启动它——否则首个 Output() 在 `OutputCh <- res`
+	// 永久阻塞,整个爆破死锁且零输出(历史 bug:曾以 OutFunc!=nil 即“是否给了 -f”为
+	// 门控,导致 stdout/-o 输出模式下 handler 不启动)。
+	if !r.ManualDrain {
 		go r.OutputHandler()
 	}
 
@@ -297,7 +303,8 @@ func (r *Runner) RunWithContext(ctx context.Context) error {
 	default:
 		return nil
 	}
-	if r.OutFunc != nil {
+	// 等内建 handler 处理完所有在飞结果再 close;ManualDrain 模式无内建 handler,直接 close。
+	if !r.ManualDrain {
 		r.outlock.Wait()
 	}
 	r.outMu.Lock()
@@ -605,7 +612,9 @@ func (r *Runner) add(task *pkg.Task) {
 }
 
 func (r *Runner) Output(res *pkg.Result) {
-	if r.OutFunc != nil {
+	// outlock 与内建 OutputHandler 配对计数(收尾 outlock.Wait() 等其处理完所有结果再
+	// close OutputCh);仅在 handler 运行(非 ManualDrain)时计数,保持平衡。
+	if !r.ManualDrain {
 		r.outlock.Add(1)
 	}
 	r.stat.RecordResult(res)
@@ -625,7 +634,9 @@ loop:
 				break loop
 			}
 			if result.OK {
-				if r.File != nil {
+				// 以写出器 OutFunc 是否存在为准(而非 File):既防 SDK 只设 File 不设 OutFunc
+				// 时 nil 调用,也允许 SDK 提供无文件的自定义 sink。
+				if r.OutFunc != nil {
 					r.OutFunc(result.Format(r.FileFormat))
 				}
 				logs.Log.Console(result.Format(r.OutputFormat))

--- a/core/runner.go
+++ b/core/runner.go
@@ -500,10 +500,15 @@ func (r *Runner) clusterBombGenerate(ctx context.Context, canceler context.Cance
 
 	go func() {
 		defer close(ch)
+		// ctx 取消(FirstOnly 命中)时用带标签 break 退出循环,落到下面的 wg.Wait()
+		// 等所有 user goroutine(ch 的发送者)退出后,再由 defer 执行 close(ch)。
+		// 绝不能在此 return:那会跳过 wg.Wait(),让 close(ch) 与仍在 `ch <- task`
+		// 的发送者并发,触发 panic: send on closed channel。
+	genLoop:
 		for _, user := range users {
 			select {
 			case <-ctx.Done():
-				return
+				break genLoop
 			default:
 			}
 			wg.Add(1)
@@ -513,7 +518,11 @@ func (r *Runner) clusterBombGenerate(ctx context.Context, canceler context.Cance
 				if !r.NoUnAuth {
 					userLocker := &sync.Mutex{}
 					userLocker.Lock()
-					ch <- &pkg.Task{
+					// 与下方 brute 发送一致:用 select 让 ctx 取消时能退出,不在无人
+					// 接收的 ch 上裸发送(裸发送在 ctx 取消时既会卡死 wg.Wait,又会与
+					// close(ch) 竞争触发 panic: send on closed channel)。
+					select {
+					case ch <- &pkg.Task{
 						ZombieResult: &parsers.ZombieResult{
 							IP:       target.IP,
 							Port:     target.Port,
@@ -527,6 +536,9 @@ func (r *Runner) clusterBombGenerate(ctx context.Context, canceler context.Cance
 						Context:  ctx,
 						Canceler: canceler,
 						Locker:   userLocker,
+					}:
+					case <-ctx.Done():
+						return
 					}
 					userLocker.Lock()
 					userLocker.Unlock()

--- a/core/runner.go
+++ b/core/runner.go
@@ -80,8 +80,8 @@ type Runner struct {
 	Addrs    utils.Addrs
 	Targets  []*Target
 	Services []string
-	// OutputCh 无缓冲。默认由内建 OutputHandler 消费;直接消费它的 SDK 调用方必须在
-	// Run 前置 RunnerOption.ManualDrain=true 并自行并发 drain,否则首个 Output() 会死锁。
+	// OutputCh 无缓冲。OutFunc 非 nil 时由内建 OutputHandler 消费;
+	// OutFunc 为 nil 的 SDK 调用方应自行并发消费。
 	OutputCh     chan *pkg.Result
 	File         *fileutils.File
 	OutFunc      func(string)
@@ -211,11 +211,7 @@ func (r *Runner) RunWithContext(ctx context.Context) error {
 		return fmt.Errorf("pitchfork mode requires auth, please set -a/-A")
 	}
 
-	// OutputHandler 是无缓冲 OutputCh 的唯一内建读者兼 console 打印者,除非调用方
-	// 显式 ManualDrain 自行消费,否则必须启动它——否则首个 Output() 在 `OutputCh <- res`
-	// 永久阻塞,整个爆破死锁且零输出(历史 bug:曾以 OutFunc!=nil 即“是否给了 -f”为
-	// 门控,导致 stdout/-o 输出模式下 handler 不启动)。
-	if !r.ManualDrain {
+	if r.OutFunc != nil {
 		go r.OutputHandler()
 	}
 
@@ -303,8 +299,7 @@ func (r *Runner) RunWithContext(ctx context.Context) error {
 	default:
 		return nil
 	}
-	// 等内建 handler 处理完所有在飞结果再 close;ManualDrain 模式无内建 handler,直接 close。
-	if !r.ManualDrain {
+	if r.OutFunc != nil {
 		r.outlock.Wait()
 	}
 	r.outMu.Lock()
@@ -507,10 +502,6 @@ func (r *Runner) clusterBombGenerate(ctx context.Context, canceler context.Cance
 
 	go func() {
 		defer close(ch)
-		// ctx 取消(FirstOnly 命中)时用带标签 break 退出循环,落到下面的 wg.Wait()
-		// 等所有 user goroutine(ch 的发送者)退出后,再由 defer 执行 close(ch)。
-		// 绝不能在此 return:那会跳过 wg.Wait(),让 close(ch) 与仍在 `ch <- task`
-		// 的发送者并发,触发 panic: send on closed channel。
 	genLoop:
 		for _, user := range users {
 			select {
@@ -525,9 +516,6 @@ func (r *Runner) clusterBombGenerate(ctx context.Context, canceler context.Cance
 				if !r.NoUnAuth {
 					userLocker := &sync.Mutex{}
 					userLocker.Lock()
-					// 与下方 brute 发送一致:用 select 让 ctx 取消时能退出,不在无人
-					// 接收的 ch 上裸发送(裸发送在 ctx 取消时既会卡死 wg.Wait,又会与
-					// close(ch) 竞争触发 panic: send on closed channel)。
 					select {
 					case ch <- &pkg.Task{
 						ZombieResult: &parsers.ZombieResult{
@@ -612,9 +600,7 @@ func (r *Runner) add(task *pkg.Task) {
 }
 
 func (r *Runner) Output(res *pkg.Result) {
-	// outlock 与内建 OutputHandler 配对计数(收尾 outlock.Wait() 等其处理完所有结果再
-	// close OutputCh);仅在 handler 运行(非 ManualDrain)时计数,保持平衡。
-	if !r.ManualDrain {
+	if r.OutFunc != nil {
 		r.outlock.Add(1)
 	}
 	r.stat.RecordResult(res)
@@ -634,9 +620,7 @@ loop:
 				break loop
 			}
 			if result.OK {
-				// 以写出器 OutFunc 是否存在为准(而非 File):既防 SDK 只设 File 不设 OutFunc
-				// 时 nil 调用,也允许 SDK 提供无文件的自定义 sink。
-				if r.OutFunc != nil {
+				if r.File != nil && r.OutFunc != nil {
 					r.OutFunc(result.Format(r.FileFormat))
 				}
 				logs.Log.Console(result.Format(r.OutputFormat))

--- a/core/runner_clusterbomb_test.go
+++ b/core/runner_clusterbomb_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/chainreactors/zombie/pkg"
+	"github.com/chainreactors/zombie/plugin"
+)
+
+type clusterBombSession struct{}
+
+func (clusterBombSession) Service() string  { return "faketest" }
+func (clusterBombSession) Close() error     { return nil }
+func (clusterBombSession) Raw() interface{} { return nil }
+
+type clusterBombPlugin struct{}
+
+func (clusterBombPlugin) Name() string                        { return "faketest" }
+func (clusterBombPlugin) Open(*pkg.Task) (pkg.Session, error) { return nil, errors.New("auth failed") }
+func (clusterBombPlugin) Unauth(*pkg.Task) (pkg.Session, error) {
+	return clusterBombSession{}, nil
+}
+
+func TestClusterBombStopsSendersBeforeClosingTaskChannel(t *testing.T) {
+	r := NewRunner(NewDefaultRunnerOption())
+	r.Plugins = map[string]plugin.Plugin{"faketest": clusterBombPlugin{}}
+	r.Quiet = true
+
+	drained := make(chan struct{})
+	go func() {
+		for range r.OutputCh {
+		}
+		close(drained)
+	}()
+
+	const nUsers = 400
+	users := make([]string, nUsers)
+	for i := range users {
+		users[i] = fmt.Sprintf("u%d", i)
+	}
+	r.SetUsers(users)
+	r.SetPasswords([]string{"x"})
+	r.SetTargets([]*Target{{IP: "127.0.0.1", Port: "1", Service: "faketest"}})
+
+	_ = r.RunWithContext(context.Background())
+	<-drained
+}

--- a/core/runner_option.go
+++ b/core/runner_option.go
@@ -15,6 +15,12 @@ type RunnerOption struct {
 	Raw             bool
 	Quiet           bool
 
+	// ManualDrain:SDK 调用方若自行消费 OutputCh,置 true 以禁用内建 OutputHandler;
+	// CLI/默认为 false,由 OutputHandler 消费 OutputCh 并打印结果。OutputHandler 是
+	// 无缓冲 OutputCh 的唯一内建读者兼 console 打印者:不启动它而又无人 drain,首个
+	// Output() 会在 `OutputCh <- res` 永久阻塞,整个爆破死锁且零输出。
+	ManualDrain bool
+
 	// Post-auth actions
 	Proton           bool
 	ScanTemplates    []string

--- a/core/runner_option.go
+++ b/core/runner_option.go
@@ -15,12 +15,6 @@ type RunnerOption struct {
 	Raw             bool
 	Quiet           bool
 
-	// ManualDrain:SDK 调用方若自行消费 OutputCh,置 true 以禁用内建 OutputHandler;
-	// CLI/默认为 false,由 OutputHandler 消费 OutputCh 并打印结果。OutputHandler 是
-	// 无缓冲 OutputCh 的唯一内建读者兼 console 打印者:不启动它而又无人 drain,首个
-	// Output() 会在 `OutputCh <- res` 永久阻塞,整个爆破死锁且零输出。
-	ManualDrain bool
-
 	// Post-auth actions
 	Proton           bool
 	ScanTemplates    []string

--- a/core/target.go
+++ b/core/target.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chainreactors/zombie/pkg"
 	"net"
 	"net/http"
+	"strings"
 )
 
 type Target struct {
@@ -41,13 +42,14 @@ func (t *Target) URL() string {
 }
 
 func (t *Target) UpdateService(s string) {
-	// 规范化为 canonical 插件名(别名 postgre→postgresql 等),否则执行期 resolvePlugin
-	// 找不到别名 key 会落到 neutron 兜底。未注册时返回小写原值+空端口(已由 Validate 拦截)。
-	canonical, port, _ := pkg.NormalizeService(s)
-	t.Service = canonical
-	if t.Port == "" {
-		t.Port = port
+	if svc, ok := pkg.Services.Get(s); ok {
+		t.Service = svc.Name
+		if t.Port == "" {
+			t.Port = svc.DefaultPort
+		}
+		return
 	}
+	t.Service = strings.ToLower(strings.TrimSpace(s))
 }
 
 func (t *Target) Addr() *utils.Addr {

--- a/core/target.go
+++ b/core/target.go
@@ -10,7 +10,6 @@ import (
 	"github.com/chainreactors/zombie/pkg"
 	"net"
 	"net/http"
-	"strings"
 )
 
 type Target struct {
@@ -42,9 +41,12 @@ func (t *Target) URL() string {
 }
 
 func (t *Target) UpdateService(s string) {
-	t.Service = strings.ToLower(s)
+	// 规范化为 canonical 插件名(别名 postgre→postgresql 等),否则执行期 resolvePlugin
+	// 找不到别名 key 会落到 neutron 兜底。未注册时返回小写原值+空端口(已由 Validate 拦截)。
+	canonical, port, _ := pkg.NormalizeService(s)
+	t.Service = canonical
 	if t.Port == "" {
-		t.Port = pkg.Services.DefaultPort(t.Service)
+		t.Port = port
 	}
 }
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -102,10 +102,7 @@ func ParseUrl(u string) (*Target, bool) {
 	}
 
 	if parsed.Scheme != "" {
-		t.Service = parsed.Scheme
-		if t.Port == "" {
-			t.Port = pkg.Services.DefaultPort(t.Service)
-		}
+		t.UpdateService(parsed.Scheme)
 		t.Scheme = parsed.Scheme
 	} else if t.Port != "" {
 		t.Service = pkg.GetDefault(t.Port)

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -48,6 +48,17 @@ func TestParseUrl(t *testing.T) {
 			},
 		},
 		{
+			name:  "service alias url with default port",
+			input: "mongodb://127.0.0.1",
+			ok:    true,
+			want: &Target{
+				IP:      "127.0.0.1",
+				Port:    "27017",
+				Service: "mongo",
+				Scheme:  "mongodb",
+			},
+		},
+		{
 			name:  "plain ip",
 			input: "127.0.0.1",
 			ok:    true,

--- a/core/worker.go
+++ b/core/worker.go
@@ -79,6 +79,11 @@ func resolvePlugin(service string, plugins map[string]plugin.Plugin) plugin.Plug
 	if p, ok := plugins[service]; ok {
 		return p
 	}
+	if s, ok := pkg.Services.Get(service); ok {
+		if p, ok := plugins[s.Name]; ok {
+			return p
+		}
+	}
 	if p, ok := plugins["neutron"]; ok {
 		return p
 	}

--- a/core/worker_test.go
+++ b/core/worker_test.go
@@ -1,0 +1,28 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/chainreactors/zombie/pkg"
+	"github.com/chainreactors/zombie/plugin"
+)
+
+type aliasPluginSession struct{}
+
+func (aliasPluginSession) Service() string  { return "mongo" }
+func (aliasPluginSession) Close() error     { return nil }
+func (aliasPluginSession) Raw() interface{} { return nil }
+
+type aliasPlugin struct{}
+
+func (aliasPlugin) Name() string                          { return "mongo" }
+func (aliasPlugin) Open(*pkg.Task) (pkg.Session, error)   { return aliasPluginSession{}, nil }
+func (aliasPlugin) Unauth(*pkg.Task) (pkg.Session, error) { return aliasPluginSession{}, nil }
+
+func TestResolvePluginAcceptsServiceAliases(t *testing.T) {
+	plugins := map[string]plugin.Plugin{"mongo": aliasPlugin{}}
+
+	if p := resolvePlugin("mongodb", plugins); p == nil || p.Name() != "mongo" {
+		t.Fatalf("resolvePlugin(mongodb) = %#v, want mongo plugin", p)
+	}
+}

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -48,6 +48,7 @@ type services struct {
 }
 
 func (ss *services) Get(name string) (*Service, bool) {
+	name = strings.ToLower(strings.TrimSpace(name))
 	if s, ok := ss.Plugins[name]; ok {
 		return s, true
 	}
@@ -73,24 +74,7 @@ func (ss *services) DefaultPort(service string) string {
 	if s, ok := ss.Get(service); ok {
 		return s.DefaultPort
 	}
-	// 未注册服务名返回空端口。不能走 utils.ParsePortsString:它解引用 utils.PrePort 全局,
-	// 而 zombie 初始化的是 fingers/resources.PrePort,utils.PrePort 恒为 nil → 对未知服务名
-	// 会 nil 解引用 SIGSEGV(见 -s memcache/-s postgres 崩溃)。未知服务统一在 Validate 期
-	// 友好报错,这里不再尝试把服务名当端口解析。
 	return ""
-}
-
-// NormalizeService 把服务名或别名规范化为 canonical 插件名(如 postgre→postgresql、
-// mongodb→mongo),并返回其默认端口。未注册返回 (lower, "", false)。
-// -s 校验 / runner.Services 过滤 / Target.UpdateService 必须统一用它:插件注册表只认
-// canonical key(RegisterPlugin("postgresql"...)),别名不在其中,否则别名会“校验通过却
-// 在执行期 resolvePlugin 落到 neutron 兜底”(实测 -s postgre/-s mongodb 跑成 neutron)。
-func NormalizeService(service string) (canonical, defaultPort string, ok bool) {
-	name := strings.ToLower(strings.TrimSpace(service))
-	if s, found := Services.Get(name); found {
-		return s.Name, s.DefaultPort, true
-	}
-	return name, "", false
 }
 
 // SupportedServiceNames 返回所有已注册服务名(已排序),供未知服务的友好报错使用。

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"github.com/chainreactors/fingers/common"
 	"github.com/chainreactors/parsers"
-	"github.com/chainreactors/utils"
 	"github.com/chainreactors/utils/httpx"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -72,12 +72,36 @@ func (ss *services) Register(s *Service) bool {
 func (ss *services) DefaultPort(service string) string {
 	if s, ok := ss.Get(service); ok {
 		return s.DefaultPort
-	} else if s := utils.ParsePortsString(service); len(s) > 0 {
-		return s[0]
 	}
+	// 未注册服务名返回空端口。不能走 utils.ParsePortsString:它解引用 utils.PrePort 全局,
+	// 而 zombie 初始化的是 fingers/resources.PrePort,utils.PrePort 恒为 nil → 对未知服务名
+	// 会 nil 解引用 SIGSEGV(见 -s memcache/-s postgres 崩溃)。未知服务统一在 Validate 期
+	// 友好报错,这里不再尝试把服务名当端口解析。
 	return ""
 }
 
+// NormalizeService 把服务名或别名规范化为 canonical 插件名(如 postgre→postgresql、
+// mongodb→mongo),并返回其默认端口。未注册返回 (lower, "", false)。
+// -s 校验 / runner.Services 过滤 / Target.UpdateService 必须统一用它:插件注册表只认
+// canonical key(RegisterPlugin("postgresql"...)),别名不在其中,否则别名会“校验通过却
+// 在执行期 resolvePlugin 落到 neutron 兜底”(实测 -s postgre/-s mongodb 跑成 neutron)。
+func NormalizeService(service string) (canonical, defaultPort string, ok bool) {
+	name := strings.ToLower(strings.TrimSpace(service))
+	if s, found := Services.Get(name); found {
+		return s.Name, s.DefaultPort, true
+	}
+	return name, "", false
+}
+
+// SupportedServiceNames 返回所有已注册服务名(已排序),供未知服务的友好报错使用。
+func SupportedServiceNames() string {
+	names := make([]string, 0, len(Services.Plugins))
+	for name := range Services.Plugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
 
 const (
 	PluginSource  = "plugin"

--- a/plugin/mongo/mongo.go
+++ b/plugin/mongo/mongo.go
@@ -92,7 +92,12 @@ func (p *MongoPlugin) Open(task *pkg.Task) (pkg.Session, error) {
 	} else {
 		url = fmt.Sprintf("mongodb://%v:%v@%v:%v", task.Username, task.Password, task.IP, task.Port)
 	}
-	clientOptions := options.Client().ApplyURI(url).SetConnectTimeout(time.Duration(task.Timeout) * time.Second)
+	// SetServerSelectionTimeout 限制 server selection / 命令等待,否则只 SetConnectTimeout
+	// 在过滤端口上仍会按驱动默认 30s 阻塞,超出 task.Timeout。
+	timeout := time.Duration(task.Timeout) * time.Second
+	clientOptions := options.Client().ApplyURI(url).
+		SetConnectTimeout(timeout).
+		SetServerSelectionTimeout(timeout)
 
 	client, err := mongo.Connect(task.Context, clientOptions)
 	if err != nil {
@@ -105,6 +110,24 @@ func (p *MongoPlugin) Open(task *pkg.Task) (pkg.Session, error) {
 	return &mongoSession{service: task.Service, client: client, ctx: task.Context}, nil
 }
 
+// Unauth 以无凭据连接,并执行需要鉴权的 listDatabases 来证明“未授权可访问”。
+// 只用 Ping 不够:mongo 的 ping 命令在开启鉴权的实例上同样放行,会把需鉴权实例
+// 误报为未授权;listDatabases 在开启鉴权时返回 Unauthorized 错误,从而正确区分
+// 真正的无认证实例(返回会话=命中)与需鉴权实例(返回错误=未命中)。
 func (p *MongoPlugin) Unauth(task *pkg.Task) (pkg.Session, error) {
-	return nil, pkg.NotImplUnauthorized
+	url := fmt.Sprintf("mongodb://%v:%v", task.IP, task.Port)
+	timeout := time.Duration(task.Timeout) * time.Second
+	clientOptions := options.Client().ApplyURI(url).
+		SetConnectTimeout(timeout).
+		SetServerSelectionTimeout(timeout)
+
+	client, err := mongo.Connect(task.Context, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := client.ListDatabaseNames(task.Context, bson.D{}); err != nil {
+		client.Disconnect(task.Context)
+		return nil, err
+	}
+	return &mongoSession{service: task.Service, client: client, ctx: task.Context}, nil
 }


### PR DESCRIPTION
本 PR 基于 `zombie2.0` 修复靶场实测发现的 4 个运行时问题，并在后续提交里收敛实现方式：不新增 `ManualDrain` / `NormalizeService` 这类额外机制，尽量复用既有 `OutFunc` 输出契约和 `Services.Get()` 别名表。

## 修复内容

### 1. 修复无 `-f` 时 stdout 模式死锁

原因是 `OutputCh` 是无缓冲 channel，CLI stdout 模式没有设置 `OutFunc`，导致内建 `OutputHandler` 不启动，worker 首次 `OutputCh <- res` 后无人接收并卡死。

最终实现保持旧的库调用契约：

- `Runner.OutFunc == nil`：不启动内建 `OutputHandler`，SDK 可以自行 drain `OutputCh`。
- `Runner.OutFunc != nil`：启动内建 `OutputHandler`，负责 stdout / 文件输出。
- `RunWithArgs` 作为 CLI 入口，在无 `-f` 时补一个 no-op `OutFunc`，只让 CLI 主动进入内建输出路径。

这样修复 CLI 死锁，同时不破坏已有 SDK 自行消费 `OutputCh` 的用法。

### 2. 修复 clusterbomb 的 `send on closed channel`

`clusterBombGenerate` 在 ctx 取消后提前 return，会跳过 `wg.Wait()`，导致 `close(ch)` 和仍在发送任务的 per-user goroutine 并发。另一个结构问题是消费端在 `targetCtx.Done()` 后直接退出，不再 drain task channel，迫使发送端承担“没人读”的兜底。

最终实现把 channel 所有权协议收回到底层：

- ctx 取消时停止继续创建 sender，但仍落到 `wg.Wait()`。
- 生成器在所有 sender 退出后才关闭 task channel。
- 消费端对 `clusterBombGenerate()` 返回的 channel 一直 range 到 close，不再因为 cancel 提前抛弃。
- unauth 任务发送保留和 brute 一样的 ctx-aware `select`，用于减少 cancel 后的无效发送。

这是 channel 生命周期的源头修复，不靠上层 recover 掩盖 panic。

### 3. 修复未知 `-s` 崩溃与服务别名执行偏差

原 `DefaultPort` 对未知服务走 `utils.ParsePortsString`，但 zombie 初始化的是 `fingers/resources.PrePort`，不是 `utils.PrePort`，因此 `-s memcache` / `-s postgres` 会触发 nil 解引用。

同时，项目本来已有 alias 机制：`Services.Get()` 会查 canonical service 和 alias。最终实现复用这套机制，而不是新增一层 normalize API：

- `Services.Get()` 负责 trim/lower + alias 查找。
- `Target.UpdateService()` 使用 `Services.Get()` 返回的 `Service.Name` 写入 canonical service。
- `Validate()`、`-s` 多值、`-S` 过滤、json/gogo target、URL scheme 都走同一套 canonical 逻辑。
- `resolvePlugin()` 底层也会先经 `Services.Get()` 解析 alias/canonical，再查插件表，避免 SDK 直接构造 alias task 时落到 neutron 兜底。
- 未知 `-s` 友好报错并列出 supported services。

覆盖场景包括：`postgre -> postgresql`、`mongodb -> mongo`、`pop -> pop3`，以及 `memcache` / `postgres` / `8080` 拒绝。

### 4. 实现 Mongo 未授权检测

`MongoPlugin.Unauth` 原来直接返回 `NotImplUnauthorized`，导致无认证 Mongo 无法被检测出来。修复为无凭据连接后执行 `listDatabases`：

- 只 `Ping` 不够，开启鉴权的 Mongo 也可能允许 ping。
- `listDatabases` 能区分真正无认证访问和需要鉴权。
- `Open` / `Unauth` 都补了 `SetServerSelectionTimeout`，避免过滤端口按 driver 默认超时拖住。

## 验证

已通过：

- `go build ./...`
- `go vet ./...`
- 定向回归测试：无 `-f` 不死锁、SDK/库调用不自动抢 `OutputCh`、服务别名 canonical、未知服务拒绝、URL alias、worker 底层 alias 解析、clusterbomb channel close、Mongo unauth probe
- `go test -race ./core -run 'TestClusterBombStopsSendersBeforeClosingTaskChannel|TestResolvePluginAcceptsServiceAliases' -count=1`

已知未通过项：

- `go test ./core ./pkg ./plugin/mongo` 仍失败于既有资源缺失：`TestNewGeneratorWithRule` / `TestWeakPass` 找不到 `../templates/zombie/rule/weakpass.rule`。该问题在 base `781b278` 上同样存在，与本 PR 无关。